### PR TITLE
fix: Use 'twill-image' as view namespace

### DIFF
--- a/src/ImageServiceProvider.php
+++ b/src/ImageServiceProvider.php
@@ -29,7 +29,7 @@ class ImageServiceProvider extends ServiceProvider
             __DIR__ . '/../config/twill-image.php',
             'twill-image',
         );
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'image');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'twill-image');
         $this->publishes(
             [
                 __DIR__ . '/../config/twill-image.php' => config_path(


### PR DESCRIPTION
This is a proposed change to make the view namespace identical to the package name. The goal is to make the `views/vendor` destination more guessable when overriding:

```
resources/views/vendor/twill-image/
```
instead of:
```
resources/views/vendor/image/
```
