### PR TITLE
Use class layout for fallback sizes

### DIFF
--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -67,7 +67,7 @@ class Image
         $this->loading = $args['loading'] ?? 'lazy';
         $this->width = $args['width'] ?? $this->data['width'];
         $this->height = $args['height'] ?? (isset($args['width']) ? $this->width / $this->data['width'] * $this->data['height'] : $this->data['height']);
-        $this->sizes = $args['sizes'] ?? $this->data['sizes'] ?? $this->getDefaultSizes($layout);
+        $this->sizes = $args['sizes'] ?? $this->data['sizes'] ?? $this->getDefaultSizes($this->layout);
         $this->wrapperClass = $args['class'] ?? false;
 
         $this->imgStyle = array_merge(


### PR DESCRIPTION
I think this fix makes sense. We were running into some issues with fallback image sizes. This seemed to solve the issue.