### PR TITLE
Minor optimizations when webp_support is not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ See [above section](#preset) about the `preset` method.
 |---|---|---|---|
 |`background_color`|`string`|`#e3e3e3`|   |
 |`lqip`|`boolean`|`true`|Uses Twill LQIP method to generate responsive placeholder|
-|`webp_support`|`boolean`|`true`|   |
+|`webp_support`|`boolean`|`true`|If set to `false`, the `type` attribute is omitted from `<source>` elements|
 |`presets`|`object`|   |   |
 
 ## Art directed images

--- a/resources/views/picture.blade.php
+++ b/resources/views/picture.blade.php
@@ -6,7 +6,9 @@ $shouldLoad = $shouldLoad ?? true;
         @isset($sources)
             @foreach($sources as $source)
                 <source
-                    type="{{ $source['type'] }}"
+                    @if(config('twill-image.webp_support'))
+                        type="{{ $source['type'] }}"
+                    @endif
                     @if(isset($source['mediaQuery']))
                         media="{{ $source['mediaQuery'] }}"
                     @endif

--- a/src/Services/MediaSource.php
+++ b/src/Services/MediaSource.php
@@ -291,7 +291,7 @@ class MediaSource implements Arrayable
 
     public function toArray()
     {
-        return [
+        return array_merge([
             "alt" => $this->alt(),
             "aspectRatio" => $this->aspectRatio(),
             "caption" => $this->caption(),
@@ -302,10 +302,11 @@ class MediaSource implements Arrayable
             "ratio" => $this->ratio(),
             "src" => $this->src(),
             "srcSet" => $this->srcSet(),
+            "width" => $this->width(),
+        ], (config('twill-image.webp_support') ? [
             "srcWebp" => $this->srcWebp(),
             "srcSetWebp" => $this->srcSetWebp(),
-            "width" => $this->width(),
-        ];
+        ] : []));
     }
 
     /**


### PR DESCRIPTION
This adds 2 checks for cases when `webp_support` is not enabled:

1. Omit the `type` attribute on the `<source>` element

    The primary use case is to work with image services that provide automatic format conversion. If this attribute is not specified, the browser should use the MIME type information from the server. ([More on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-type))

2. Omit the `srcWebp` and `srcSetWebp` keys in the media source `toArray()` output
