### PR TITLE
Add the ability to pass params through to the underlying ImageService

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Twill Image is a package designed to work with [Twill](https://twill.io) to disp
       - [`sizes`](#sizes)
       - [`columns`](#columns)
       - [`srcSetWidths`](#srcSetWidths)
+      - [`params`](#params)
       - [`preset`](#preset)
       - [`render`](#render)
       - [`toArray`](#toArray)
@@ -100,10 +101,10 @@ The JavaScript module is not required. If you prefer to rely only on the browser
 The `Image` model allows you to interact fluently with a media object.
 
 ```php
-$image = new A17\Twill\Image\Models\Image($object, $role, $media);
+$image = new A17\Twill\Image\Models\Image($object, $role, $media, $params);
 
 // or using the Facade
-$image = TwillImage::make($object, $role, $media);
+$image = TwillImage::make($object, $role, $media, $params);
 ```
 
 |Argument|Type|Default|Description|
@@ -111,6 +112,7 @@ $image = TwillImage::make($object, $role, $media);
 |`$object` (Required)|`A17\Twill\Models\Media` `A17\Twill\Models\Block` `object`|   |Your Twill module or block object|
 |`$role` (Required)|`string`|   |`Media` role|
 |`$media`|`A17\Twill\Models\Media`|`null`|`Media` instance|
+|`$params`|`array`|`[]`|Array of extra parameters for the ImageService
 
 #### Available methods
 
@@ -154,6 +156,7 @@ $image->crop('desktop')->sources([
         'crop' => 'mobile', // required
         'width' => 200, // optional
         'height' => 200, // optional
+        'params' => ['q'=> 60], //optional
         'srcSetWidths' => [100, 200, 400], // optional
     ],
     [
@@ -219,6 +222,14 @@ Use this method to give a list a widths to generate the `srcset` attribute. With
 $image->srcSetWidths([100, 150, 300, 600, 1200, 2000, 2400, 3600, 5000]);
 ```
 
+##### `params`
+
+This method allows you to pass an array of extra params for the underlying ImageService (e.g. Imgix,Glide).
+
+```php
+$image->params(['q' => 50, 'filt' => 'greyscale']);
+```
+
 ##### `preset`
 
 With this method you can use an object to pass a value to any of the above methods. You can also add a preset key to the config `config/twill-image.php` and pass the name to this method.
@@ -232,6 +243,7 @@ return [
         'art_directed' => [
             'crop' => 'desktop',
             'width' => 700,
+            'params' => ['q' => 75],
             'sizes' => '(max-width: 767px) 25vw, (min-width: 767px) and (max-width: 1023px) 50vw, 33vw',
             'srcSetWidths' => [350, 700, 1400],
             'sources' => [

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -200,7 +200,6 @@ class Image implements Arrayable
     public function params($params)
     {
         $this->params = $params;
-        $this->mediaSourceService->setParams($params);
 
         return $this;
     }

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -43,6 +43,11 @@ class Image implements Arrayable
     protected $height;
 
     /**
+     * @var array The imageservice params
+     */
+    protected $params;
+
+    /**
      * @var array The media sources
      */
     protected $sources = [];
@@ -62,7 +67,7 @@ class Image implements Arrayable
      * @param string $role
      * @param null|Media $media
      */
-    public function __construct($object, $role, $media = null)
+    public function __construct($object, $role, $media = null, $params = [])
     {
         $this->object = $object;
 
@@ -70,10 +75,13 @@ class Image implements Arrayable
 
         $this->media = $media;
 
+        $this->params = $params;
+
         $this->mediaSourceService = new MediaSource(
             $this->object,
             $this->role,
-            $this->media
+            $this->media,
+            $this->params,
         );
 
         $columnsServiceClass = config('twill-image.columns_class', ImageColumns::class);
@@ -184,6 +192,20 @@ class Image implements Arrayable
     }
 
     /**
+     * Set extra image service params
+     *
+     * @param array $params
+     * @return $this
+     */
+    public function params($params)
+    {
+        $this->params = $params;
+        $this->mediaSourceService->setParams($params);
+
+        return $this;
+    }
+
+    /**
      * Set alternative sources for the media.
      *
      * @param array $sources
@@ -211,6 +233,7 @@ class Image implements Arrayable
                     $source['width'] ?? null,
                     $source['height'] ?? null,
                     $source['srcSetWidths'] ?? [],
+                    $source['params'] ?? [],
                 )->toArray()
             ];
         }
@@ -260,6 +283,10 @@ class Image implements Arrayable
 
         if (isset($preset['height'])) {
             $this->height($preset['height']);
+        }
+
+        if (isset($preset['params'])) {
+            $this->params($preset['params']);
         }
 
         if (isset($preset['sizes'])) {

--- a/src/Services/MediaSource.php
+++ b/src/Services/MediaSource.php
@@ -65,13 +65,7 @@ class MediaSource implements Arrayable
 
         return $this;
     }
-
-    public function setParams($params)
-    {
-        $this->params = $params ?? [];
-    }
-
-
+    
     protected function setModel($object)
     {
         if (!classHasTrait($object, 'A17\Twill\Models\Behaviors\HasMedias')) {
@@ -120,6 +114,11 @@ class MediaSource implements Arrayable
     protected function setHeight($height)
     {
         $this->height = $height ?? null;
+    }
+
+    public function setParams($params)
+    {
+        $this->params = $params ?? [];
     }
 
     protected function setImageArray()

--- a/src/Services/MediaSource.php
+++ b/src/Services/MediaSource.php
@@ -33,6 +33,8 @@ class MediaSource implements Arrayable
 
     protected $imageArray;
 
+    protected $params;
+
     /**
      * Create an instance of the service
      *
@@ -40,27 +42,35 @@ class MediaSource implements Arrayable
      * @param string $role
      * @param array $args
      * @param Media|object|null $media
-     * @param int[] $srcSetWidths
+     * @param array $params
      */
-    public function __construct($object, $role, $media = null)
+    public function __construct($object, $role, $media = null, $params = [])
     {
         $this->setModel($object);
 
         $this->role = $role;
         $this->media = $media;
+        $this->params = $params;
     }
 
-    public function generate($crop = null, $width = null, $height = null, $srcSetWidths = [])
+    public function generate($crop = null, $width = null, $height = null, $srcSetWidths = [], $params=[])
     {
         $this->setCrop($crop);
         $this->setWidth($width);
         $this->setHeight($height);
+        $this->setParams($params);
         $this->setImageArray();
 
         $this->srcSetWidths = $srcSetWidths;
 
         return $this;
     }
+
+    public function setParams($params)
+    {
+        $this->params = $params ?? [];
+    }
+
 
     protected function setModel($object)
     {
@@ -117,7 +127,7 @@ class MediaSource implements Arrayable
         $this->imageArray = $this->model->imageAsArray(
             $this->role,
             $this->crop,
-            [],
+            $this->params,
             $this->media,
         );
 
@@ -144,7 +154,7 @@ class MediaSource implements Arrayable
             $args['fm'] = $format;
         }
 
-        return $args;
+        return array_merge($this->params, $args);
     }
 
     protected function calcHeightFromWidth($width)

--- a/src/TwillImage.php
+++ b/src/TwillImage.php
@@ -14,11 +14,12 @@ class TwillImage
      * @param object|Model|Block $object
      * @param string $role
      * @param null|Media $media
+     * @param null|array $params
      * @return Image
      */
-    public function make($object, $role, $media = null)
+    public function make($object, $role, $media = null, $params = [])
     {
-        return new Image($object, $role, $media);
+        return new Image($object, $role, $media, $params);
     }
 
     /**


### PR DESCRIPTION
I've been really enjoying using Twill Image - it's made managing images within a site so much easier! 

However while using it I came a cross a couple of things that couldn't be achieved with Twill Image due to the inability to pass parameters to the ImageService.

In one instance instance I wanted to greyscale an image and the the other, possibly more common use case would be to amend the quality of the image. When handling large banner images and high-density screens I tend to adjust the image quality down on the larger images for hiDPI screens as the density covers up the lower quality and it means a much smaller image can be delivered. [reference](https://jakearchibald.com/2021/serving-sharp-images-to-high-density-screens/)

This PR adds the ability to pass a params array through the Image model to the ImageService

```php
TwillImage::make($object, 'crop', null, ['q' => 50]);
```

```php
$image = TwillImage::make($object, 'crop');

$image->params('filt' => 'sepia');
```

You can also add the params array into the preset array in `twill-image.php`

```php
'presets' => [
    'art_directed' => [
        'crop' => 'desktop',
        'width' => 700,
        'params' => ['q' => 75],
    ]
],
```

It is also possible to pass the params via the sources array too - this allows for different params (quality settings) per media query.

```php
'presets' => [
    'art_directed' => [
        'crop' => 'desktop',
        'width' => 700,
        'params' => ['q' => 75],
        'sizes' => '(max-width: 767px) 25vw, (min-width: 767px) and (max-width: 1023px) 50vw, 33vw',
        'srcSetWidths' => [350, 700, 1400],
        'sources' => [
                [
                    'crop' => 'mobile',
                    'media_query' => '(max-width: 767px)',
                    'srcSetWidths' => [100, 200, 400],
                ],
                [
                    'crop' => 'desktop',
                    'media_query' => '(min-width: 769px) and (-webkit-min-device-pixel-ratio: 1.5)',
                    'params' => ['q' => 40],
                    'srcSetWidths' => [1600, 2400],
                ],
            ]
    ]
],
```

This is tested as far as my use case goes - so this may not be feature-complete, and I expect it may require further work.  But this was just a quickly put-together PR to see whether this is something  you'd want in the library.

