### PR TITLE
The sizes attribute only if srcset is also present

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -1,14 +1,13 @@
-@php
-$shouldLoad = $shouldLoad ?? true;
-@endphp
 <img
     decoding="async"
     @isset($loading) loading="{{$loading}}" @endisset
-    @if($shouldLoad) src="{{$src}}" @endif
+    @if($shouldLoad = $shouldLoad ?? true) src="{{$src}}" @endif
     @if(!$shouldLoad) data-src="{{$src}}" @endif
-    @if($shouldLoad && isset($srcSet)) srcSet="{{$srcSet}}" @endif
+    @if($shouldLoad && isset($srcSet))
+        @isset($sizes) sizes="{{$sizes}}" @endisset
+        srcset="{{$srcSet}}"
+    @endif
     @if(!$shouldLoad && isset($srcSet)) data-srcset="{{$srcSet}}" @endif
-    @isset($sizes) sizes="{{$sizes}}" @endisset
     @isset($alt) alt="{{$alt}}" @endisset
     @isset($style) style="{{$style}}" @endisset
     @isset($attributes) {!! $attributes !!} @endisset


### PR DESCRIPTION
When I test HTML markup by https://validator.w3.org I got this error:

```
Error: The sizes attribute may be specified only if the srcset attribute is also present.
```

**More info here:**
https://rocketvalidator.com/html-validation/the-sizes-attribute-may-be-specified-only-if-the-srcset-attribute-is-also-present

**Changes:**
- attribute `srcSet` renamed to `srcset`
- render attribute `sizes` only if `srcset` is also present


