### PR TITLE
Typings updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,13 @@
     }
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.0"
+    "friendsofphp/php-cs-fixer": "^3.0",
+    "larastan/larastan": "^2.0",
+    "phpstan/phpstan": "^1.12"
+  },
+  "scripts": {
+    "lint": [
+      "vendor/bin/phpstan analyse -c phpstan.neon src"
+    ]
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 5
+
+    paths:
+        - src
+
+    universalObjectCratesClasses:
+
+    reportUnmatchedIgnoredErrors: false

--- a/src/Facades/TwillImage.php
+++ b/src/Facades/TwillImage.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 class TwillImage extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'twill.image';
     }

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Application;
 
 class GlideController
 {
-    public function __invoke($path, Application $app)
+    public function __invoke(string $path, Application $app)
     {
         return $app->make(Glide::class)->render($path);
     }

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -68,7 +68,7 @@ class Image implements Arrayable
      * @param string $role
      * @param null|Media $media
      */
-    public function __construct($object, $role, $media = null)
+    public function __construct($object, string $role, ?Media $media = null)
     {
         $this->object = $object;
 
@@ -86,16 +86,14 @@ class Image implements Arrayable
     /**
      * @return MediaSource
      */
-    private function mediaSourceService()
+    private function mediaSourceService(): MediaSource
     {
-        return isset($this->mediaSourceService)
-            ? $this->mediaSourceService
-            : $this->mediaSourceService = new MediaSource(
-                $this->object,
-                $this->role,
-                $this->media,
-                $this->service,
-            );
+        return $this->mediaSourceService ?? $this->mediaSourceService = new MediaSource(
+            $this->object,
+            $this->role,
+            $this->media,
+            $this->service,
+        );
     }
 
     /**
@@ -103,8 +101,9 @@ class Image implements Arrayable
      *
      * @param array|string $preset
      * @return $this
+     * @throws ImageException
      */
-    public function preset($preset)
+    public function preset($preset): Image
     {
         if (is_array($preset)) {
             $this->applyPreset($preset);
@@ -139,9 +138,8 @@ class Image implements Arrayable
      * Set the list of srcset width to generate
      *
      * @param int[] $widths
-     * @return $this
      */
-    public function srcSetWidths($widths)
+    public function srcSetWidths(array $widths)
     {
         $this->srcSetWidths = $widths;
     }
@@ -152,7 +150,7 @@ class Image implements Arrayable
      * @param string $crop
      * @return $this
      */
-    public function crop($crop)
+    public function crop($crop): Image
     {
         $this->crop = $crop;
 
@@ -165,7 +163,7 @@ class Image implements Arrayable
      * @param int $width
      * @return $this
      */
-    public function width($width)
+    public function width(int $width): Image
     {
         $this->width = $width;
 
@@ -178,7 +176,7 @@ class Image implements Arrayable
      * @param int $height
      * @return $this
      */
-    public function height($height)
+    public function height(int $height): Image
     {
         $this->height = $height;
 
@@ -191,7 +189,7 @@ class Image implements Arrayable
      * @param string $sizes
      * @return $this
      */
-    public function sizes($sizes)
+    public function sizes(string $sizes): Image
     {
         $this->sizes = $sizes;
 
@@ -204,7 +202,7 @@ class Image implements Arrayable
      * @param array $sources
      * @return $this
      */
-    public function sources($sources = [])
+    public function sources(array $sources = []): Image
     {
         $this->sources = $sources;
 
@@ -218,7 +216,7 @@ class Image implements Arrayable
      * @param array $service
      * @return $this
      */
-    public function service($service)
+    public function service(array $service): Image
     {
         $this->service = $service;
 
@@ -228,10 +226,9 @@ class Image implements Arrayable
     /**
      * Set alternative sources for the media.
      *
-     * @param array $sources
-     * @return $this
+     * @throws ImageException
      */
-    public function generateSources()
+    public function generateSources(): array
     {
         $sources = [];
 
@@ -270,7 +267,10 @@ class Image implements Arrayable
         return TwillImage::render($this, $overrides);
     }
 
-    public function toArray()
+    /**
+     * @throws ImageException
+     */
+    public function toArray(): array
     {
         $arr = [
             "image" => $this->mediaSourceService()->generate(

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -7,9 +7,12 @@ use A17\Twill\Models\Model;
 use A17\Twill\Image\Facades\TwillImage;
 use A17\Twill\Image\Services\MediaSource;
 use A17\Twill\Image\Services\ImageColumns;
+use A17\Twill\Services\MediaLibrary\ImageService;
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Support\Arrayable;
 use A17\Twill\Image\Exceptions\ImageException;
 use A17\Twill\Services\MediaLibrary\ImageServiceInterface;
+use Illuminate\Foundation\Application;
 
 class Image implements Arrayable
 {
@@ -59,9 +62,21 @@ class Image implements Arrayable
     protected $srcSetWidths = [];
 
     /**
-     * @var string|ImageServiceInterface ImageService instance or class name
+     * ImageService instance or class name
+     *
+     * @var string|ImageServiceInterface
      */
     protected $service;
+
+    /**
+     * @var ImageColumns|mixed
+     */
+    private $columnsService;
+
+    /**
+     * @var MediaSource|mixed
+     */
+    private $mediaSourceService;
 
     /**
      * @param object|Model $object
@@ -85,6 +100,7 @@ class Image implements Arrayable
 
     /**
      * @return MediaSource
+     * @throws ImageException
      */
     private function mediaSourceService(): MediaSource
     {
@@ -92,7 +108,7 @@ class Image implements Arrayable
             $this->object,
             $this->role,
             $this->media,
-            $this->service,
+            $this->service
         );
     }
 
@@ -213,10 +229,10 @@ class Image implements Arrayable
      * Set the ImageService to use instead of the one provided
      * by the service container
      *
-     * @param array $service
+     * @param string|ImageServiceInterface $service
      * @return $this
      */
-    public function service(array $service): Image
+    public function service($service): Image
     {
         $this->service = $service;
 
@@ -232,7 +248,7 @@ class Image implements Arrayable
     {
         $sources = [];
 
-        foreach ($this->sources ?? [] as $source) {
+        foreach ($this->sources as $source) {
             if (!isset($source['media_query']) && !isset($source['mediaQuery']) && !isset($source['columns'])) {
                 throw new ImageException("Media query is mandatory in sources.");
             }
@@ -249,7 +265,7 @@ class Image implements Arrayable
                     $source['crop'],
                     $source['width'] ?? null,
                     $source['height'] ?? null,
-                    $source['srcSetWidths'] ?? [],
+                    $source['srcSetWidths'] ?? []
                 )->toArray()
             ];
         }
@@ -264,6 +280,7 @@ class Image implements Arrayable
      */
     public function render($overrides = [])
     {
+        /* @phpstan-ignore-next-line */
         return TwillImage::render($this, $overrides);
     }
 

--- a/src/Models/StaticImage.php
+++ b/src/Models/StaticImage.php
@@ -3,7 +3,7 @@
 namespace A17\Twill\Image\Models;
 
 use A17\Twill\Models\Model;
-use A17\Twill\Image\Models\Image;
+use A17\Twill\Image\Models\Image as TwillImageModel;
 use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Image\Exceptions\ImageException;
 
@@ -17,7 +17,7 @@ class StaticImage extends Model
 
     public static $role = 'static-image';
 
-    public static function makeFromSrc($args)
+    public static function makeFromSrc($args): TwillImageModel
     {
         $model = self::make();
 

--- a/src/Models/StaticImage.php
+++ b/src/Models/StaticImage.php
@@ -13,12 +13,14 @@ class StaticImage extends Model
 
     protected $fillable = [];
 
-    public $mediasParams = [];
-
     public static $role = 'static-image';
 
+    /**
+     * @throws ImageException
+     */
     public static function makeFromSrc($args): TwillImageModel
     {
+        /* @phpstan-ignore-next-line */
         $model = self::make();
 
         $role = self::$role;
@@ -39,7 +41,8 @@ class StaticImage extends Model
             'alt' => $args['alt'] ?? null,
         ]);
 
-        if (!empty($preset['sources']) && $sources = $preset['sources']) {
+        if (!empty($preset['sources'])) {
+            $sources = $preset['sources'] ?? [];
             foreach ($sources as $source) {
                 $model->makeMedia([
                     'src' => self::getFile($files, $source['crop']),
@@ -114,6 +117,7 @@ class StaticImage extends Model
 
         $cropData = $this->calcCrop($width, $height, $ratio);
 
+        /* @phpstan-ignore-next-line */
         $media = \A17\Twill\Models\Media::make([
             'uuid' => $uuid,
             'filename' => basename($uuid),
@@ -131,15 +135,16 @@ class StaticImage extends Model
             $this,
             $data,
             config('twill.mediables_table', 'twill_mediables'),
-            true,
+            true
         );
 
         $media->setRelation('pivot', $pivot);
 
+        /* @phpstan-ignore-next-line */
         $this->medias->add($media);
     }
 
-    private function getInputSize($uuid)
+    private function getInputSize($uuid): array
     {
         $file_path = implode('/', [
             rtrim(config('twill-image.static_local_path'), '/'),

--- a/src/Services/ImageStyles.php
+++ b/src/Services/ImageStyles.php
@@ -23,21 +23,21 @@ class ImageStyles
      * Set up the service to generate view inline styles for the wrapper, main image and placeholder elements
      *
      * @param array $styles
-     * @param array $classes
+     * @param string $classes
      * @return void
      */
-    public function setup($styles = [], $classes = '')
+    public function setup(array $styles = [], string $classes = '')
     {
         $this->mode = config('twill-image.mode');
         $this->setBaseStyling($styles, $classes);
     }
 
     /**
-     * Return inline stylesand classes for the wrapper element
+     * Return inline styles and classes for the wrapper element
      *
      * @return array
      */
-    public function wrapper()
+    public function wrapper(): array
     {
         $styles = $this->inlineStyles['wrapper'] ?? [];
         $classes = $this->classes['wrapper'] ?? [];
@@ -46,11 +46,11 @@ class ImageStyles
     }
 
     /**
-     * Return inline stylesand classes for the placeholder element
+     * Return inline styles and classes for the placeholder element
      *
      * @return array
      */
-    public function placeholder()
+    public function placeholder(): array
     {
         $styles = array_merge(
             $this->inlineStyles['main'] ?? [],

--- a/src/Services/MediaSource.php
+++ b/src/Services/MediaSource.php
@@ -5,6 +5,7 @@ namespace A17\Twill\Image\Services;
 use A17\Twill\Models\Block;
 use A17\Twill\Models\Media;
 use A17\Twill\Models\Model;
+use A17\Twill\Services\MediaLibrary\ImageService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Support\Arrayable;
@@ -36,6 +37,10 @@ class MediaSource implements Arrayable
     protected $height;
 
     protected $imageArray;
+    /**
+     * @var ImageServiceInterface|string
+     */
+    private $service;
 
     /**
      * Create an instance of the service
@@ -43,7 +48,7 @@ class MediaSource implements Arrayable
      * @param Model|Block|object $object
      * @param string $role
      * @param Media|object|null $media
-     * @param null $service
+     * @param ImageService|string|null $service
      * @throws ImageException
      */
     public function __construct($object, string $role, $media = null, $service = null)
@@ -75,6 +80,7 @@ class MediaSource implements Arrayable
      */
     protected function setModel($object)
     {
+        /* @phpstan-ignore-next-line */
         if (!classHasTrait($object, 'A17\Twill\Models\Behaviors\HasMedias')) {
             throw new ImageException('Object must use HasMedias trait', 1);
         }
@@ -275,7 +281,7 @@ class MediaSource implements Arrayable
         return $this->height ?? $this->calcHeightFromWidth($this->width);
     }
 
-    public function aspectRatio(): string
+    public function aspectRatio(): float
     {
         $width = $this->width;
 

--- a/src/Services/MediaSource.php
+++ b/src/Services/MediaSource.php
@@ -298,7 +298,7 @@ class MediaSource implements Arrayable
         return pathinfo($this->media()->filename, PATHINFO_EXTENSION);
     }
 
-    public function ratio(): string
+    public function ratio(): ?string
     {
         return $this->media()->pivot->ratio;
     }

--- a/src/TwillImage.php
+++ b/src/TwillImage.php
@@ -5,29 +5,30 @@ namespace A17\Twill\Image;
 use A17\Twill\Models\Block;
 use A17\Twill\Models\Media;
 use A17\Twill\Models\Model;
-use A17\Twill\Image\Models\Image;
+use A17\Twill\Image\Models\Image as TwillImageModel;
 use A17\Twill\Image\Models\StaticImage;
 use A17\Twill\Image\ViewModels\ImageViewModel;
+use Illuminate\View\View;
 
 class TwillImage
 {
     /**
      * @param object|Model|Block $object
      * @param string $role
-     * @param null|Media $media
-     * @return Image
+     * @param Media|null $media
+     * @return TwillImageModel
      */
-    public function make($object, $role, $media = null)
+    public function make($object, string $role, Media $media = null): TwillImageModel
     {
-        return new Image($object, $role, $media);
+        return new TwillImageModel($object, $role, $media);
     }
 
     /**
-     * @param Image|array $data
+     * @param TwillImageModel|array $data
      * @param array $overrides
-     * @return string
+     * @return View
      */
-    public function render($data, $overrides = [])
+    public function render($data, array $overrides = []): View
     {
         $viewModel = new ImageViewModel($data, $overrides);
 

--- a/src/TwillImage.php
+++ b/src/TwillImage.php
@@ -6,9 +6,8 @@ use A17\Twill\Models\Block;
 use A17\Twill\Models\Media;
 use A17\Twill\Models\Model;
 use A17\Twill\Image\Models\Image as TwillImageModel;
-use A17\Twill\Image\Models\StaticImage;
 use A17\Twill\Image\ViewModels\ImageViewModel;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\View;
 
 class TwillImage
 {

--- a/src/TwillStaticImage.php
+++ b/src/TwillStaticImage.php
@@ -2,11 +2,12 @@
 
 namespace A17\Twill\Image;
 
+use A17\Twill\Image\Models\Image;
 use A17\Twill\Image\Models\StaticImage;
 
 class TwillStaticImage
 {
-    public function make($args)
+    public function make($args): Image
     {
         return StaticImage::makeFromSrc($args);
     }

--- a/src/ViewModels/ImageViewModel.php
+++ b/src/ViewModels/ImageViewModel.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Image\ViewModels;
 
+use A17\Twill\Image\Exceptions\ImageException;
 use Spatie\ViewModels\ViewModel;
 use A17\Twill\Image\Models\Image;
 use A17\Twill\Image\Services\ImageStyles;
@@ -21,7 +22,7 @@ class ImageViewModel extends ViewModel implements Arrayable
     protected $data;
 
     /**
-     * @var int $height Height of the image
+     * @var int|null $height Height of the image
      */
     protected $height;
 
@@ -46,7 +47,7 @@ class ImageViewModel extends ViewModel implements Arrayable
     protected $lqipSources;
 
     /**
-     * @var string $lqipSrc Default LQIP image source url
+     * @var ?string $lqipSrc Default LQIP image source url
      */
     protected $lqipSrc;
 
@@ -66,17 +67,17 @@ class ImageViewModel extends ViewModel implements Arrayable
     protected $src;
 
     /**
-     * @var int $width Width of the image
+     * @var int|null $width Width of the image
      */
     protected $width;
 
     /**
-     * @var int $imageClass Tailwind CSS class applied to the placeholder and main img tag
+     * @var mixed $imageClass Tailwind CSS class applied to the placeholder and main img tag
      */
     protected $imageClass;
 
     /**
-     * @var int $imageStyles Styles applied to the placeholder and main img tag
+     * @var mixed $imageStyles Styles applied to the placeholder and main img tag
      */
     protected $imageStyles;
 
@@ -86,15 +87,25 @@ class ImageViewModel extends ViewModel implements Arrayable
     protected $styleService;
 
     /**
-     * @var int $wrapperClass CSS class added to the wrapper element
+     * @var ?string $wrapperClass CSS class added to the wrapper element
      */
     protected $wrapperClass;
+
+    /**
+     * @var bool
+     */
+    protected $needPlaceholder;
+    /**
+     * @var bool
+     */
+    protected $needPlaceholderOrSizer;
 
     /**
      * ImageViewModel format an Image instance attributes to be passed to the image wrapper view.
      *
      * @param Image|array $data Image source
      * @param array $overrides Overrides frontend options
+     * @throws ImageException
      */
     public function __construct($data, $overrides = [])
     {
@@ -343,7 +354,7 @@ class ImageViewModel extends ViewModel implements Arrayable
             'sizes' => $this->sizes,
             'width' => $this->width,
             'wrapperClasses' => $this->wrapperClasses(),
-            'wrapperStyles' => $wrapperStyles ?? null,
+            'wrapperStyles' => $wrapperStyles,
         ]);
     }
 }

--- a/src/ViewModels/ImageViewModel.php
+++ b/src/ViewModels/ImageViewModel.php
@@ -125,7 +125,7 @@ class ImageViewModel extends ViewModel implements Arrayable
      * @param array $overrides
      * @return void
      */
-    protected function setAttributes($overrides)
+    protected function setAttributes(array $overrides)
     {
         $this->lqip
             = $overrides['lqip']
@@ -235,7 +235,7 @@ class ImageViewModel extends ViewModel implements Arrayable
         ]);
     }
 
-    protected function mimeType($extension)
+    protected function mimeType(string $extension): ?string
     {
         $ext = strtolower($extension);
 
@@ -261,7 +261,7 @@ class ImageViewModel extends ViewModel implements Arrayable
         return null;
     }
 
-    protected function wrapperClasses()
+    protected function wrapperClasses(): string
     {
         $classes = 'twill-image-wrapper';
 
@@ -269,9 +269,7 @@ class ImageViewModel extends ViewModel implements Arrayable
             $classes = join(' ', [$classes, $this->wrapperClass]);
         }
 
-        $classes = join(' ', [$classes, $this->styleService->wrapper()['class']]);
-
-        return $classes;
+        return join(' ', [$classes, $this->styleService->wrapper()['class']]);
     }
 
     /**


### PR DESCRIPTION
On some projects, I was getting 500 issues because some types was properly defined or wrong. 

For example, ratios method was returning null but current typing suggest it should return a string. 

I did a pass on the full codebase to adjust typings and enable static analysis with phpstan configure on level 5.

Currently static-analysis needs to be run manually with `composer lint` command but we could image add automated run on staged files. 

In addition, I also aliased some imported model to have better helpers generated with plugin like laravel-ide-helper. Current model Image name was conflicting with Image class during helpers generation. 

